### PR TITLE
CON-2484-split-ga-image-to-build-images-only-when-related-files-are-changed

### DIFF
--- a/.github/workflows/ga-build-content-api-gateway.yml
+++ b/.github/workflows/ga-build-content-api-gateway.yml
@@ -1,8 +1,11 @@
-name: 🐳 On Master - Build and Test Docker Image
+name: 🐳 On Master - Build Content API Gateway Docker Image
 
 on:
   push:
-    branches: ["master"]
+    branches:
+      - 'master'
+    paths:
+      - 'srcs/api-gateway-app/**'
 
 jobs:
   build-image:
@@ -28,7 +31,6 @@ jobs:
           password: ${{ secrets.SECRET_DOCKER_01EDU_ORG }}
 
       - name: 🏗️ Build the 🚀 API Gateway image
-        if: always()
         run: |
           docker build srcs/api-gateway-app/ --file srcs/api-gateway-app/Dockerfile --tag ghcr.io/01-edu/content-api-gateway-app
           docker push ghcr.io/01-edu/content-api-gateway-app

--- a/.github/workflows/ga-build-content-billing-app.yml
+++ b/.github/workflows/ga-build-content-billing-app.yml
@@ -1,8 +1,11 @@
-name: 🐳 On Master - Build and Test Docker Image
+name: 🐳 On Master - Build Content Billing App Docker Image
 
 on:
   push:
-    branches: ["master"]
+    branches:
+      - 'master'
+    paths:
+      - 'srcs/billing-app/**'
 
 jobs:
   build-image:
@@ -27,8 +30,7 @@ jobs:
           username: ${{ secrets.USER_DOCKER_01EDU_ORG }}
           password: ${{ secrets.SECRET_DOCKER_01EDU_ORG }}
 
-      - name: 🏗️ Build the 🚀 API Gateway image
-        if: always()
+      - name: 🏗️ Build the 💰 Billing App image
         run: |
-          docker build srcs/api-gateway-app/ --file srcs/api-gateway-app/Dockerfile --tag ghcr.io/01-edu/content-api-gateway-app
-          docker push ghcr.io/01-edu/content-api-gateway-app
+          docker build srcs/billing-app/ --file srcs/billing-app/Dockerfile --tag ghcr.io/01-edu/content-billing-app
+          docker push ghcr.io/01-edu/content-billing-app

--- a/.github/workflows/ga-build-content-inventory-app.yml
+++ b/.github/workflows/ga-build-content-inventory-app.yml
@@ -1,8 +1,11 @@
-name: 🐳 On Master - Build and Test Docker Image
+name: 🐳 On Master - Build Content Inventory App Docker Image
 
 on:
   push:
-    branches: ["master"]
+    branches:
+      - 'master'
+    paths:
+      - 'srcs/inventory-app/**'
 
 jobs:
   build-image:
@@ -27,14 +30,7 @@ jobs:
           username: ${{ secrets.USER_DOCKER_01EDU_ORG }}
           password: ${{ secrets.SECRET_DOCKER_01EDU_ORG }}
 
-      - name: 🏗️ Build the 🚀 API Gateway image
-        if: always()
+      - name: 🏗️ Build the 🧩 Inventory App image
         run: |
-          docker build srcs/api-gateway-app/ --file srcs/api-gateway-app/Dockerfile --tag ghcr.io/01-edu/content-api-gateway-app
-          docker push ghcr.io/01-edu/content-api-gateway-app
-
-      - name: 🏗️ Build the 💰 Billing App image
-        if: always()
-        run: |
-          docker build srcs/billing-app/ --file srcs/billing-app/Dockerfile --tag ghcr.io/01-edu/content-billing-app
-          docker push ghcr.io/01-edu/content-billing-app
+          docker build srcs/inventory-app/ --file srcs/inventory-app/Dockerfile --tag ghcr.io/01-edu/content-inventory-app
+          docker push ghcr.io/01-edu/content-inventory-app

--- a/.github/workflows/ga-build-content-rabbitmq.yml
+++ b/.github/workflows/ga-build-content-rabbitmq.yml
@@ -1,0 +1,36 @@
+name: 🐳 On Master - Build Content RabbitMQ Docker Image
+
+on:
+  push:
+    branches:
+      - 'master'
+    paths:
+      - 'srcs/rabbitmq/**'
+
+jobs:
+  build-image:
+    name: 🏗️ Build Image
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: 🐧 Checkout
+        uses: actions/checkout@v3
+
+      - name: 📦 Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: 🐳 Login to docker.01-edu.org Registry
+        uses: docker/login-action@v2
+        with:
+          registry: docker.01-edu.org
+          username: ${{ secrets.USER_DOCKER_01EDU_ORG }}
+          password: ${{ secrets.SECRET_DOCKER_01EDU_ORG }}
+
+      - name: 🏗️ Build the 🐰 Rabbitmq image
+        run: |
+          docker build srcs/rabbitmq/ --file srcs/rabbitmq/Dockerfile --tag ghcr.io/01-edu/content-rabbitmq
+          docker push ghcr.io/01-edu/content-rabbitmq

--- a/.github/workflows/ga-image-build-master.yml
+++ b/.github/workflows/ga-image-build-master.yml
@@ -44,9 +44,3 @@ jobs:
         run: |
           docker build srcs/inventory-app/ --file srcs/inventory-app/Dockerfile --tag ghcr.io/01-edu/content-inventory-app
           docker push ghcr.io/01-edu/content-inventory-app
-
-      - name: 🏗️ Build the 🐰 Rabbitmq image
-        if: always()
-        run: |
-          docker build srcs/rabbitmq/ --file srcs/rabbitmq/Dockerfile --tag ghcr.io/01-edu/content-rabbitmq
-          docker push ghcr.io/01-edu/content-rabbitmq


### PR DESCRIPTION
Split "monolit" GA to build docker images into separate files to trigger the image building only when related files are changed.